### PR TITLE
fix: use our bot's credentials to authenticate against GitHub registry

### DIFF
--- a/.github/workflows/update-semver.yml
+++ b/.github/workflows/update-semver.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_TOKEN_ADMIN }}
       - uses: ./


### PR DESCRIPTION
The previous approach did not work and now we try to login with our bot's token.