### PR TITLE
fix: authenticate using docker CLI

### DIFF
--- a/.github/workflows/update-semver.yml
+++ b/.github/workflows/update-semver.yml
@@ -11,9 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN_ADMIN }}
+      - run: echo "${{ secrets.GH_TOKEN_ADMIN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - uses: ./


### PR DESCRIPTION
Docs: https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token